### PR TITLE
chore: Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/k6_cloud.yml
+++ b/.github/workflows/k6_cloud.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
       
       - name: Run Test
-        uses: grafana/k6-action@v0.2.0
+        uses: grafana/k6-action@55845c6c2e400af4356c84e5b514aeabb1bfdbd4 # v0.2.0
         id: runtest
         with:
           cloud: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
       
       - name: Run Test
-        uses: grafana/k6-action@v0.2.0
+        uses: grafana/k6-action@55845c6c2e400af4356c84e5b514aeabb1bfdbd4 # v0.2.0
         with:
           filename: main.js
           flags: -v -q # verbose, quiet


### PR DESCRIPTION
## Summary

- Pin all public GitHub Action tag references to full commit SHAs for supply chain security
- Version tags preserved as inline comments for readability
- Internal `grafana/` workflow references left as-is

## Why

Tag-based action references are mutable, a compromised tag can inject malicious code into CI without any visible change in workflow files. Pinning to immutable commit SHAs prevents this attack vector.